### PR TITLE
Fix bogus "listen() failed" errors

### DIFF
--- a/lib/TCP/LowLevel/Socket-Linux.pm6
+++ b/lib/TCP/LowLevel/Socket-Linux.pm6
@@ -254,7 +254,7 @@ method find-bound-port(-->Int) {
 }
 
 # listen(sockfd, backlog)
-sub native-listen(int32, int32) is native is symbol('listen') {*}
+sub native-listen(int32, int32 -->int32) is native is symbol('listen') {*}
 
 method listen(-->Nil) {
     if $!state ≠ SOCKET_BOUND { die "Socket in improper state ( $!state )" }


### PR DESCRIPTION
The native-listen function did not have a specified return value. Apparently a bug in the previous NativeCall implementation caused a return value to appear anyway, but the new implementation actually does what it's told. So add a return type to get a proper return value.